### PR TITLE
Change `*RawRevisionString` in `sqSCCSVersion.h` to contain only short commit id

### DIFF
--- a/.git_filters/RevDateURL.smudge
+++ b/.git_filters/RevDateURL.smudge
@@ -30,6 +30,11 @@ $date =~ s/\s+$//m;
 $shorthash = `git log --format=%h -1`;
 $shorthash =~ s/\s+$//m;
 
+#
+# No, I want $Rev to be the revision, so:
+#
+$myrev = $shorthash;
+
 while (<STDIN>) {
     s/\$Date[^\$]*\$/\$Date: $date \$/;
     s/\$URL[^\$]*\$/\$URL: $url \$/;


### PR DESCRIPTION
The main reason for this change is really that this string is also used to determine plugin directory and if someone adds slash into its branch name, things no longer work.